### PR TITLE
목록 갱신 스레드 <-> UI 처리 스레드 Safe하게 수정, 클라이언트 강제 종료 후 UI 즉시 갱신하도록 수정

### DIFF
--- a/CPU_Preference_Changer/BackgroundTask/ProcessListRefreshTask.cs
+++ b/CPU_Preference_Changer/BackgroundTask/ProcessListRefreshTask.cs
@@ -40,6 +40,14 @@ namespace CPU_Preference_Changer.BackgroundTask {
         }
 
         /// <summary>
+        /// task작업을 최대한 빨리 실행시키게 한다.
+        /// </summary>
+        public void taskRunAsPossibleAsFast()
+        {
+            runCount = 0;
+        }
+
+        /// <summary>
         /// 주기적으로 실행 되는 함수... 5번 실행 될 때 마다 목록을 갱신한다
         /// (주기 : 함수 실행 주기 1초, 5회 => 5초마다 갱신)
         /// </summary>

--- a/CPU_Preference_Changer/Core/MMHGlobal.cs
+++ b/CPU_Preference_Changer/Core/MMHGlobal.cs
@@ -25,9 +25,6 @@ namespace CPU_Preference_Changer.Core {
         /// </summary>
         public HBFT sysShutdownTaskHandle { get; set; }
 
-
-
-
         public MMHGlobal()
         {
             sysShutdownTaskHandle = null;

--- a/CPU_Preference_Changer/MabiProcessListView/LV_MabiProcess.xaml
+++ b/CPU_Preference_Changer/MabiProcessListView/LV_MabiProcess.xaml
@@ -60,17 +60,11 @@
                                                 Tag="{Binding Path=tbCoreStateIdxTag}"/>
                                         <CheckBox Content="더미!" Visibility="Hidden" />
                                         <CheckBox Content="숨김"
-                                                  MouseLeftButtonDown="cbHide_MouseLeftButtonDown"
-                                                  MouseLeftButtonUp="cbHide_MouseLeftButtonUp"
-                                                  MouseLeave="cbHide_MouseLeave" 
                                                   Unchecked="cbHide_Unchecked"
                                                   Checked="cbHide_Checked"
                                                   IsChecked="{Binding Path=isHide}"
                                                   Tag="{Binding Path=tbCoreStateIdxTag}"/>
                                         <CheckBox Content="예약종료"
-                                                  MouseLeftButtonDown="cbRK_MouseLeftButtonDown"
-                                                  MouseLeftButtonUp="cbRK_MouseLeftButtonUp"
-                                                  MouseLeave="cbRK_MouseLeave" 
                                                   Checked="cbRK_Checked"
                                                   Unchecked="cbRK_Unchecked"
                                                   IsChecked="{Binding Path=isKillReserved}"

--- a/CPU_Preference_Changer/MabiProcessListView/LV_MabiProcessData.cs
+++ b/CPU_Preference_Changer/MabiProcessListView/LV_MabiProcessData.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Threading;
 
 namespace CPU_Preference_Changer.MabiProcessListView
 {
@@ -154,34 +153,7 @@ namespace CPU_Preference_Changer.MabiProcessListView
     /// </summary>
     public class LvMabiDataCollection : ObservableCollection<LV_MabiProcessRowData>
     {
-        /// <summary>
-        /// 리스트뷰 데이터를 여러 스레드에서 접근하여 읽어가기만 하면 괜찮은데
-        /// 어떤 경우 여러 스레드에서 Write를 시도할 수도 있어서 그럴 때 Lock을 걸기위함
-        /// </summary>
-        private Mutex dataMutex;
-
-        public LvMabiDataCollection()
-        {
-            dataMutex = new Mutex();
-        }
-
         int itmIdx = 0;
-
-        /// <summary>
-        /// 데이터 락 설정
-        /// </summary>
-        public void waitForSingleObject()
-        {
-            dataMutex.WaitOne();
-        }
-
-        /// <summary>
-        /// 데이터 락 해제
-        /// </summary>
-        public void ReleaseMutex()
-        {
-            dataMutex.ReleaseMutex();
-        }
 
         /// <summary>
         /// add함수 재정의,,, 자동으로 idx를 생성한 뒤 넣게한다!

--- a/CPU_Preference_Changer/UI/MainUI/MainWindow.xaml.cs
+++ b/CPU_Preference_Changer/UI/MainUI/MainWindow.xaml.cs
@@ -274,12 +274,19 @@ namespace CPU_Preference_Changer.UI.MainUI
                     /*by LT인척하는엘프 2021.06.13
                      귀찮아서 무조건 Set하던것을.. 기존 아이템과 비교하여
                      목록을 적절히 갱신시키게 함!*/
+                    /*독립된 스레드이므로 버튼 클릭과 겹치게 되면 곤란하다
+                      예: 버튼 클릭 이벤트에서 리스트를 참조중인데 
+                          하필 그 순간 프로세스 종료가 감지되어서 여기서 바로 삭제되면...?
+                          버튼 클릭이벤트에서 제대로 작동이 되지 않을 수 있다.
+                          확실하게 데이터에 Lock을 걸어두고 참조하게 한다.*/
+                    lvMabiProcess.LvMabi_WaitSingleObject();
                     var curList = lvMabiProcess.getLvItems();
                     if (curList == null) {
                         lvMabiProcess.setDataSoure(newList);
                     } else {
                         curList.updateDataCollection(newList, removeReservedInfo);
                     }
+                    lvMabiProcess.LvMabi_ReleaseMutex();
                 }));
             }
         }

--- a/CPU_Preference_Changer/UI/MainUI/MainWindowClickEvt.cs
+++ b/CPU_Preference_Changer/UI/MainUI/MainWindowClickEvt.cs
@@ -201,11 +201,17 @@ namespace CPU_Preference_Changer.UI.MainUI {
 
             tsf.ShowDialog();
             if (tsf.DialogResult == System.Windows.Forms.DialogResult.OK) {
-                /* PID<->예약시간 쌍으로 맞아야한다! 
-                   => 프로세스 목록 갱신 후 사라지거나 하면 예약종료도 자동 취소해야하니까...*/
+                
+                /* 새로운 Task를 생성하고.. */
                 killTask = new MabiClientKillTask(rowParam.PID,tsf.selTime);
+
+                /*Task와 연동 될 이벤트 연결*/
+                killTask.onClientProcessKilled += MabiClientKillTask_onClientProcessKilled;
+
+                /*Task매니저에 작업 등록*/
                 rowParam.hReservedKillTask = backTmgr.addFreqTask(killTask);
 
+                /*리스트뷰에 예약된 시간을 출력한다.*/
                 rowData.reservedKillTime = tsf.selTime.ToString();
                 /*윈도우 Notify 이용하여 알려줌..
                    => 윈도우7은 안되니까 메세지 박스로 간단하게 한다.*/
@@ -213,6 +219,15 @@ namespace CPU_Preference_Changer.UI.MainUI {
             }
             /*유저가 취소했으니 체크박스도 다시 해제한다.*/
             rowData.isKillReserved = false;
+        }
+
+        /// <summary>
+        /// 클라이언트가 강제종료되었을 때 일어나는 이벤트 처리 함수
+        /// </summary>
+        /// <param name="sender"></param>
+        private void MabiClientKillTask_onClientProcessKilled(object sender)
+        {
+            RefresMabiProcess();
         }
 
         /// <summary>
@@ -229,7 +244,6 @@ namespace CPU_Preference_Changer.UI.MainUI {
                 MabiProcess.UnSetHideWindow(((LvRowParam)rowData.userParam).PID);
             }
         }
-
 
         ListSortDirection sortDirection = ListSortDirection.Ascending;
         /// <summary>


### PR DESCRIPTION
ProcessList Refresh과정은 독립된 스레드에서 Task로 관리되고 있기때문에
UI클릭이벤트와 동시에 발생할 수 있다.
따라서 매우 운이 나쁜 경우...
 독립된 스레드에서 클라이언트 종료를 감지하여 프로세스 목록을 update시키는 중
 UI클릭이벤트가 발생하게되면 잘못된 데이터를 참조하게 될 수 있다.
따라서 동기화 코드를 넣어줌.

클라이언트 강제종료 Task에서 강제 종료 성공 시 UI를 바로 갱신하도록  프로세스 Kill 이벤트 추가 및 화면과 연동시킴 
(운나쁘면 5초동안 강종된 프로세스가 목록에 떠있음)