### PR TITLE
프로세스 숨김해제 시 죽는 문제 수정

### DIFF
--- a/CPU_Preference_Changer/Core/ProgramVersionChecker.cs
+++ b/CPU_Preference_Changer/Core/ProgramVersionChecker.cs
@@ -127,7 +127,7 @@ namespace CPU_Preference_Changer.Core {
         static ProgramVersionChecker()
         {
             version_date = "2021.07.16";
-            version_revValue = "1.000"; /* 소수점 3자리 비어있더라도 3자리까지 꽉채울 것!*/
+            version_revValue = "1.001"; /* 소수점 3자리 비어있더라도 3자리까지 꽉채울 것!*/
             currentVersion = string.Format("{0}_REV_{1}",version_date,version_revValue);
 
             if (isValidVer(currentVersion) == false) {

--- a/CPU_Preference_Changer/UI/MainUI/MainWindow.xaml.cs
+++ b/CPU_Preference_Changer/UI/MainUI/MainWindow.xaml.cs
@@ -400,6 +400,12 @@ namespace CPU_Preference_Changer.UI.MainUI
             }
         }
 
+        /// <summary>
+        /// 프로그램 버전 검사 (비동기 처리를 위해 함수 분리)
+        /// </summary>
+        /// <returns>-1 새 버전 있음
+        ///           0 최신버전임
+        ///           1 알아보던 중 오류 발생..</returns>
         private int ProgramVersionCheckSubProc()
         {
             try {

--- a/CPU_Preference_Changer/UI/MainUI/MainWindowClickEvt.cs
+++ b/CPU_Preference_Changer/UI/MainUI/MainWindowClickEvt.cs
@@ -167,8 +167,8 @@ namespace CPU_Preference_Changer.UI.MainUI {
         /// <param name="e"></param>
         private void menu_SystemPowerOff_Click(object sender, RoutedEventArgs e)
         {
-            /*TODO : 1)시스템 예약 종료시간을 입력받고, 예약종료 걸어두기.
-                     2)만약 이미 예약종료를 걸어두었다면?? 취소할 수 있게 취소 걸어두기 */
+            dbgLogWriteStr("menu_SystemPowerOff_Click", "System Shutdown Click Start");
+
             MMHGlobal gInstance = MMHGlobalInstance<MMHGlobal>.GetInstance();
             BackgroundFreqTaskMgmt taskMgr = gInstance.backgroundFreqTaskManager;
 
@@ -208,6 +208,8 @@ namespace CPU_Preference_Changer.UI.MainUI {
                 menu_SystemPowerOff.IsChecked = true;
                 Interlocked.Increment(ref gInstance.reservedTaskCount);
             }
+
+            dbgLogWriteStr("menu_SystemPowerOff_Click", "System Shutdown Click End");
         }
 
         /// <summary>
@@ -216,6 +218,8 @@ namespace CPU_Preference_Changer.UI.MainUI {
         /// <param name="rowData"></param>
         private void LvMabiProcess_onCbRkClicked(LV_MabiProcessRowData rowData)
         {
+            dbgLogWriteStr("LvMabiProcess_onCbRkClicked", "Process Reserv Kill Click Start");
+
             TimeSelectForm tsf = new TimeSelectForm("종료할 시간을 선택하세요??");
             MMHGlobal gInstance = MMHGlobalInstance<MMHGlobal>.GetInstance();
             BackgroundFreqTaskMgmt backTmgr = gInstance.backgroundFreqTaskManager;
@@ -228,6 +232,7 @@ namespace CPU_Preference_Changer.UI.MainUI {
                 rowParam.hReservedKillTask = null;
                 rowData.reservedKillTime = "None";
                 Interlocked.Decrement(ref gInstance.reservedTaskCount);
+                dbgLogWriteStr("LvMabiProcess_onCbRkClicked", "Process Reserv Kill Click End");
                 return;
             }
 
@@ -258,10 +263,12 @@ namespace CPU_Preference_Changer.UI.MainUI {
 
                 /*예약된 작업 수량 증가.*/
                 Interlocked.Increment(ref gInstance.reservedTaskCount);
+                dbgLogWriteStr("LvMabiProcess_onCbRkClicked", "Process Reserv Kill Click End");
                 return;
             }
             /*유저가 취소했으니 체크박스도 다시 해제한다.*/
             rowData.isKillReserved = false;
+            dbgLogWriteStr("LvMabiProcess_onCbRkClicked", "Process Reserv Kill Click End");
         }
 
         /// <summary>
@@ -282,16 +289,22 @@ namespace CPU_Preference_Changer.UI.MainUI {
         private void LvMabiProcess_onCbHideClicked(LV_MabiProcessRowData rowData)
         {
             try {
+                dbgLogWriteStr("LvMabiProcess_onCbHideClicked", "Hide Click Start");
                 if (rowData.isHide) {
                     /*보여진 것을 숨겨야하는 케이스*/
                     MabiProcess.SetHideWindow(((LvRowParam)rowData.userParam).PID);
                 } else {
                     /*숨겨진 것을 보이게 만드는 케이스*/
-                    MabiProcess.UnSetHideWindow(((LvRowParam)rowData.userParam).PID);
+                    MabiProcess.UnSetHideWindow((uint)((LvRowParam)rowData.userParam).PID,
+                        (Exception err) =>
+                        {
+                            programErrLogWrite(err);
+                        });
                 }
             }catch (Exception err) {
                 programErrLogWrite(err);
             }
+            dbgLogWriteStr("LvMabiProcess_onCbHideClicked", "Hide Click end");
         }
 
         ListSortDirection sortDirection = ListSortDirection.Ascending;

--- a/CPU_Preference_Changer/WinAPI/WinAPI.cs
+++ b/CPU_Preference_Changer/WinAPI/WinAPI.cs
@@ -115,7 +115,7 @@ namespace CPU_Preference_Changer.WinAPI_Wrapper {
         /// <param name="hwnd">윈도우 핸들</param>
         /// <param name="lParam">사용자 Param</param>
         /// <returns></returns>
-        public delegate bool EnumWindowsProc(IntPtr hwnd, int lParam);
+        public delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
 
         /// <summary>
         /// 모든 윈도우를 순회하는 윈도우 API함수.
@@ -125,7 +125,7 @@ namespace CPU_Preference_Changer.WinAPI_Wrapper {
         /// <returns></returns>
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, int lParam);
+        public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
 
         /// <summary>
         /// 윈도우 핸들을 통해 PID값을 얻어오는 WIN32 API 함수
@@ -145,5 +145,13 @@ namespace CPU_Preference_Changer.WinAPI_Wrapper {
         /// <returns></returns>
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         public static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+        /// <summary>
+        /// Get Winddow Text Length
+        /// </summary>
+        /// <param name="hWnd"></param>
+        /// <returns></returns>
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        public static extern int GetWindowTextLength(IntPtr hWnd);
     }
 }


### PR DESCRIPTION
1. 버그 수정 - 클라이언트를 최소화 한 이후 숨김해제를 실행할 시 프로그램이 죽는 문제
   => EnumWindow콜백함수 중  WinAPI.GetWindowText(hwnd, sb, 256);이 문제였음.
         StringBuilder를 필요한 길이만큼 할당하고, 해당 길이를 참고하여 Text를 얻도록 수정...

2. 디버그모드로 실행 시 숨김, 프로세스킬, 시스템 종료 작동시에도 로그에 남기게 함..